### PR TITLE
feat: add mappings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,3 +13,4 @@ export {
   fromHexToCodepoint,
   stripHex,
 } from "./hexcodes";
+export { mapUnicodeVersion, UNICODE_MAPPINGS } from "./mappings";

--- a/src/mappings.ts
+++ b/src/mappings.ts
@@ -1,0 +1,43 @@
+export const UNICODE_MAPPINGS: Record<string, string> = {
+  "1.1.0": "1.1-Update",
+  "1.1.5": "1.1-Update1",
+  "2.0.0": "2.0-Update",
+
+  // there was no files for 2.1.0
+  // https://www.unicode.org/versions/Unicode2.1.0/
+  "2.1.0": "2.1-Update4",
+  "2.1.1": "2.1-Update",
+  "2.1.2": "2.1-Update1",
+  "2.1.5": "2.1-Update2",
+  "2.1.8": "2.1-Update3",
+  "2.1.9": "2.1-Update4",
+
+  "3.0.0": "3.0-Update",
+  "3.0.1": "3.0-Update1",
+  "3.1.0": "3.1-Update",
+  "3.1.1": "3.1-Update1",
+  "3.2.0": "3.2-Update",
+
+  "4.0.0": "4.0-Update",
+  "4.0.1": "4.0-Update1",
+};
+
+/**
+ * Maps a Unicode version to its corresponding mapped version if available.
+ * If the version is not found in the mappings, returns the original version.
+ * This is useful for handling newer Unicode versions that are not yet mapped.
+ *
+ * @param {string} version - The Unicode version to map
+ * @returns {string} The mapped Unicode version or the original version if not mapped
+ */
+export function mapUnicodeVersion(version: string): string {
+  // Check if the version is in the mappings
+  const mappedVersion = UNICODE_MAPPINGS[version];
+  if (mappedVersion) {
+    return mappedVersion;
+  }
+
+  // if not found, return the original version
+  // since newer versions are not mapped
+  return version;
+}

--- a/src/mappings.ts
+++ b/src/mappings.ts
@@ -1,6 +1,10 @@
 export const UNICODE_MAPPINGS: Record<string, string> = {
+  // there was no files published for 1.0.0,
+  // so we just use 1.1-Update for those versions
+  // https://www.unicode.org/versions/Unicode1.0.0/
+  "1.0.0": "1.1-Update",
   "1.1.0": "1.1-Update",
-  "1.1.5": "1.1-Update1",
+  "1.1.5": "1.1-Update",
   "2.0.0": "2.0-Update",
 
   // there was no files for 2.1.0
@@ -31,7 +35,7 @@ export const UNICODE_MAPPINGS: Record<string, string> = {
  * @returns {string} The mapped Unicode version or the original version if not mapped
  */
 export function mapUnicodeVersion(version: string): string {
-  // Check if the version is in the mappings
+  // check if the version is in the mappings
   const mappedVersion = UNICODE_MAPPINGS[version];
   if (mappedVersion) {
     return mappedVersion;

--- a/test/mappings.test.ts
+++ b/test/mappings.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { mapUnicodeVersion, UNICODE_MAPPINGS } from "../src/mappings";
+
+describe("mapUnicodeVersion", () => {
+  it("should return the mapped version when the version exists in mappings", () => {
+    expect(mapUnicodeVersion("1.1.0")).toBe("1.1-Update");
+    expect(mapUnicodeVersion("2.1.9")).toBe("2.1-Update4");
+    expect(mapUnicodeVersion("3.2.0")).toBe("3.2-Update");
+    expect(mapUnicodeVersion("4.0.1")).toBe("4.0-Update1");
+  });
+
+  it("should return the original version when the version does not exist in mappings", () => {
+    expect(mapUnicodeVersion("5.0.0")).toBe("5.0.0");
+    expect(mapUnicodeVersion("14.0.0")).toBe("14.0.0");
+    expect(mapUnicodeVersion("unknown")).toBe("unknown");
+  });
+
+  it("should handle all defined mappings correctly", () => {
+    Object.entries(UNICODE_MAPPINGS).forEach(([version, expectedMapping]) => {
+      expect(mapUnicodeVersion(version)).toBe(expectedMapping);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds some utilities for mapping unicode versions to their correct version that contains ucd files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for mapping Unicode version strings to their closest available updates.
	- Exposed new utilities for Unicode version mapping in the public API.
- **Tests**
	- Introduced unit tests to ensure correct behavior of Unicode version mapping functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->