### PR TITLE
feat: add dash boundary

### DIFF
--- a/src/data-files.ts
+++ b/src/data-files.ts
@@ -2,6 +2,7 @@ import type { UCDSectionWithLines } from "./types";
 
 export const HASH_BOUNDARY_REGEX = /^\s*#\s*#{2,}\s*$/;
 export const EQUALS_BOUNDARY_REGEX = /^\s*#\s*={2,}\s*$/;
+export const DASH_BOUNDARY_REGEX = /^\s*#\s*-{2,}\s*$/;
 
 /**
  * Represents a raw Unicode data file with methods to access its content.
@@ -351,6 +352,30 @@ export function isEqualsBoundary(line: string): boolean {
   }
 
   return EQUALS_BOUNDARY_REGEX.test(line);
+}
+
+/**
+ * Determines if a line contains a dash boundary pattern.
+ *
+ * A dash boundary is a line containing a pattern like "# ---" (# followed by multiple -).
+ * These patterns are used in Unicode data files to separate different sections of content.
+ *
+ * @param {string} line - The line to check
+ * @returns {boolean} True if the line contains a dash boundary pattern, false otherwise
+ *
+ * @example
+ * ```ts
+ * isDashBoundary("# -----"); // true
+ * isDashBoundary("# Some text"); // false
+ * isDashBoundary(""); // false
+ * ```
+ */
+export function isDashBoundary(line: string): boolean {
+  if (!line) {
+    return false;
+  }
+
+  return DASH_BOUNDARY_REGEX.test(line);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,12 +7,14 @@ export {
   type UnicodeVersionMetadata,
 } from "./constants";
 export {
+  DASH_BOUNDARY_REGEX,
   EQUALS_BOUNDARY_REGEX,
   HASH_BOUNDARY_REGEX,
   hasSections,
   inferFileName,
   inferVersion,
   isCommentLine,
+  isDashBoundary,
   isEmptyLine,
   isEqualsBoundary,
   isHashBoundary,

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -11,6 +11,7 @@ it("exports-snapshot", async () => {
   expect(manifest.exports).toMatchInlineSnapshot(`
       {
         ".": {
+          "DASH_BOUNDARY_REGEX": "object",
           "EQUALS_BOUNDARY_REGEX": "object",
           "HASH_BOUNDARY_REGEX": "object",
           "RawDataFile": "function",
@@ -27,6 +28,7 @@ it("exports-snapshot", async () => {
           "inferFileName": "function",
           "inferVersion": "function",
           "isCommentLine": "function",
+          "isDashBoundary": "function",
           "isEmptyLine": "function",
           "isEqualsBoundary": "function",
           "isHashBoundary": "function",
@@ -39,6 +41,7 @@ it("exports-snapshot", async () => {
           "stripHex": "function",
         },
         "./data-files": {
+          "DASH_BOUNDARY_REGEX": "object",
           "EQUALS_BOUNDARY_REGEX": "object",
           "HASH_BOUNDARY_REGEX": "object",
           "RawDataFile": "function",
@@ -46,6 +49,7 @@ it("exports-snapshot", async () => {
           "inferFileName": "function",
           "inferVersion": "function",
           "isCommentLine": "function",
+          "isDashBoundary": "function",
           "isEmptyLine": "function",
           "isEqualsBoundary": "function",
           "isHashBoundary": "function",


### PR DESCRIPTION
This PR implements a new dash boundary, which appears in some of the data-files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a utility to identify lines containing a hash followed by two or more dashes.
- **Tests**
  - Updated tests to confirm the correct export of the new utility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->