### PR TITLE
feat: add EmptyCommentNode type and corresponding type guard function

### DIFF
--- a/src/datafile/ast-utils.ts
+++ b/src/datafile/ast-utils.ts
@@ -3,9 +3,19 @@ import {
   isBoundaryNode,
   isCommentNode,
   isDataNode,
+  isEmptyCommentNode,
   isEmptyNode,
   isUnknownNode,
 } from "./typeguards";
+
+const NODE_TYPE_CHECKERS = {
+  "comment": isCommentNode,
+  "empty-comment": isEmptyCommentNode,
+  "boundary": isBoundaryNode,
+  "data": isDataNode,
+  "empty": isEmptyNode,
+  "unknown": isUnknownNode,
+};
 
 /**
  * Checks if the next N nodes from a given index are all comment nodes
@@ -88,13 +98,7 @@ export function hasConsecutiveNodesOfType(
   if (startIndex < 0 || count <= 0) return false;
   if (startIndex + count > root.children.length) return false;
 
-  const typeCheckers = {
-    comment: isCommentNode,
-    boundary: isBoundaryNode,
-    data: isDataNode,
-    empty: isEmptyNode,
-    unknown: isUnknownNode,
-  };
+  const typeCheckers = NODE_TYPE_CHECKERS;
 
   const checker = typeCheckers[nodeType];
   if (!checker) return false;
@@ -124,18 +128,10 @@ export function hasNodePattern(
     return false;
   }
 
-  const typeCheckers = {
-    comment: isCommentNode,
-    boundary: isBoundaryNode,
-    data: isDataNode,
-    empty: isEmptyNode,
-    unknown: isUnknownNode,
-  };
-
   for (let i = 0; i < pattern.length; i++) {
     const nodeIndex = startIndex + i;
     const expectedType = pattern[i];
-    const checker = typeCheckers[expectedType];
+    const checker = NODE_TYPE_CHECKERS[expectedType];
 
     if (!checker || !checker(root.children[nodeIndex])) {
       return false;
@@ -206,15 +202,7 @@ export function hasMinNodesOfType(
   nodeType: ChildNode["type"],
   minCount: number,
 ): boolean {
-  const typeCheckers = {
-    comment: isCommentNode,
-    boundary: isBoundaryNode,
-    data: isDataNode,
-    empty: isEmptyNode,
-    unknown: isUnknownNode,
-  };
-
-  const checker = typeCheckers[nodeType];
+  const checker = NODE_TYPE_CHECKERS[nodeType];
   if (!checker) return false;
 
   let count = 0;
@@ -239,15 +227,7 @@ export function allNodesAreOfType(
 ): boolean {
   if (root.children.length === 0) return false;
 
-  const typeCheckers = {
-    comment: isCommentNode,
-    boundary: isBoundaryNode,
-    data: isDataNode,
-    empty: isEmptyNode,
-    unknown: isUnknownNode,
-  };
-
-  const checker = typeCheckers[nodeType];
+  const checker = NODE_TYPE_CHECKERS[nodeType];
   if (!checker) return false;
 
   return root.children.every((child) => checker(child));

--- a/src/datafile/ast.ts
+++ b/src/datafile/ast.ts
@@ -3,6 +3,7 @@ import type { BoundaryStyle } from "../line-helpers";
 export const NodeTypes = {
   ROOT: "root",
   COMMENT: "comment",
+  EMPTY_COMMENT: "empty-comment",
   BOUNDARY: "boundary",
   DATA: "data",
   EMPTY: "empty",
@@ -29,6 +30,10 @@ export interface CommentNode extends BaseNode {
   type: "comment";
 }
 
+export interface EmptyCommentNode extends BaseNode {
+  type: "empty-comment";
+}
+
 export interface BoundaryNode extends BaseNode {
   type: "boundary";
   style: BoundaryStyle;
@@ -52,6 +57,7 @@ export interface UnknownNode extends BaseNode {
 // All node types except root
 export type ChildNode =
   | CommentNode
+  | EmptyCommentNode
   | BoundaryNode
   | DataNode
   | EmptyNode

--- a/src/datafile/typeguards.ts
+++ b/src/datafile/typeguards.ts
@@ -2,6 +2,7 @@ import type {
   BoundaryNode,
   CommentNode,
   DataNode,
+  EmptyCommentNode,
   EmptyNode,
   Node,
   RootNode,
@@ -9,18 +10,23 @@ import type {
 } from "./ast";
 
 /**
- * Type guard function that checks if an unknown value is a DataFileNode.
- * A DataFileNode must be an object with both 'type' and 'raw' properties of the correct types.
+ * Type guard function that checks if an unknown value is a Node.
+ * A Node must be an object with 'type', 'value', 'raw', and 'line' properties of the correct types.
  *
  * @param {unknown} node - The unknown value to check
- * @returns {node is Node} True if the node is a valid DataFileNode, false otherwise
+ * @returns {node is Node} True if the node is a valid Node, false otherwise
  *
  * @example
  * ```typescript
- * const unknownValue = getSomeData();
- * if (isNode(unknownValue)) {
- *   // TypeScript now knows this is a DataFileNode
- *   console.log(`Node type: ${unknownValue.type}`);
+ * import { parseDataFile } from './parser';
+ *
+ * const parsedData = parseDataFile('# Comment\n0000..007F; Basic Latin');
+ * const firstChild = parsedData.children[0];
+ *
+ * if (isNode(firstChild)) {
+ *   console.log(`Node type: ${firstChild.type}`);
+ *   console.log(`Raw content: ${firstChild.raw}`);
+ *   console.log(`Line number: ${firstChild.line}`);
  * }
  * ```
  */
@@ -36,18 +42,22 @@ export function isNode(node: unknown): node is Node {
 }
 
 /**
- * Type guard function that checks if an unknown value is a DataFileCommentNode.
- * A DataFileCommentNode must be a valid DataFileNode with the type property set to "comment".
+ * Type guard function that checks if an unknown value is a CommentNode.
+ * A CommentNode must be a valid Node with the type property set to "comment".
  *
  * @param {unknown} node - The unknown value to check
- * @returns {node is CommentNode} True if the node is a valid DataFileCommentNode, false otherwise
+ * @returns {node is CommentNode} True if the node is a valid CommentNode, false otherwise
  *
  * @example
  * ```typescript
- * const unknownValue = getSomeData();
- * if (isCommentNode(unknownValue)) {
- *   // TypeScript now knows this is a DataFileCommentNode
- *   console.log(`Comment node value: ${unknownValue.value}`);
+ * import { parseDataFile } from './parser';
+ *
+ * const parsedData = parseDataFile('# This is a comment\n0000; NULL');
+ * const commentNode = parsedData.children[0];
+ *
+ * if (isCommentNode(commentNode)) {
+ *   console.log(`Comment content: ${commentNode.value}`); // "This is a comment"
+ *   console.log(`Raw line: ${commentNode.raw}`); // "# This is a comment"
  * }
  * ```
  */
@@ -56,18 +66,46 @@ export function isCommentNode(node: unknown): node is CommentNode {
 }
 
 /**
- * Type guard function that checks if an unknown value is a DataFileBoundaryNode.
- * A DataFileBoundaryNode must be a valid DataFileNode with the type property set to "boundary".
+ * Type guard function that checks if an unknown value is an EmptyCommentNode.
+ * An EmptyCommentNode must be a valid Node with the type property set to "empty-comment".
  *
  * @param {unknown} node - The unknown value to check
- * @returns {node is BoundaryNode} True if the node is a valid DataFileBoundaryNode, false otherwise
+ * @returns {node is EmptyCommentNode} True if the node is a valid EmptyCommentNode, false otherwise
  *
  * @example
  * ```typescript
- * const unknownValue = getSomeData();
- * if (isBoundaryNode(unknownValue)) {
- *   // TypeScript now knows this is a DataFileBoundaryNode
- *   console.log(`Boundary style: ${unknownValue.style}`);
+ * import { parseDataFile } from './parser';
+ *
+ * const parsedData = parseDataFile('#\n0000; NULL');
+ * const emptyCommentNode = parsedData.children[0];
+ *
+ * if (isEmptyCommentNode(emptyCommentNode)) {
+ *   console.log(`Empty comment raw: ${emptyCommentNode.raw}`); // "#"
+ *   console.log(`Empty comment value: "${emptyCommentNode.value}"`); // ""
+ * }
+ * ```
+ */
+export function isEmptyCommentNode(node: unknown): node is EmptyCommentNode {
+  return isNode(node) && node.type === "empty-comment";
+}
+
+/**
+ * Type guard function that checks if an unknown value is a BoundaryNode.
+ * A BoundaryNode must be a valid Node with the type property set to "boundary".
+ *
+ * @param {unknown} node - The unknown value to check
+ * @returns {node is BoundaryNode} True if the node is a valid BoundaryNode, false otherwise
+ *
+ * @example
+ * ```typescript
+ * import { parseDataFile } from './parser';
+ *
+ * const parsedData = parseDataFile('# ================================================\n0000; NULL');
+ * const boundaryNode = parsedData.children[0];
+ *
+ * if (isBoundaryNode(boundaryNode)) {
+ *   console.log(`Boundary style: ${boundaryNode.style}`); // "equals"
+ *   console.log(`Boundary raw: ${boundaryNode.raw}`); // "# ================================================"
  * }
  * ```
  */
@@ -76,18 +114,23 @@ export function isBoundaryNode(node: unknown): node is BoundaryNode {
 }
 
 /**
- * Type guard function that checks if an unknown value is a DataFileDataNode.
- * A DataFileDataNode must be a valid DataFileNode with the type property set to "data".
+ * Type guard function that checks if an unknown value is a DataNode.
+ * A DataNode must be a valid Node with the type property set to "data".
  *
  * @param {unknown} node - The unknown value to check
- * @returns {node is DataNode} True if the node is a valid DataFileDataNode, false otherwise
+ * @returns {node is DataNode} True if the node is a valid DataNode, false otherwise
  *
  * @example
  * ```typescript
- * const unknownValue = getSomeData();
- * if (isDataNode(unknownValue)) {
- *   // TypeScript now knows this is a DataFileDataNode
- *   console.log(`Data node value: ${unknownValue.value}`);
+ * import { parseDataFile } from './parser';
+ *
+ * const parsedData = parseDataFile('0000..007F    ; Basic Latin  # [128] <control-0000>..<control-007F>');
+ * const dataNode = parsedData.children[0];
+ *
+ * if (isDataNode(dataNode)) {
+ *   console.log(`Data value: ${dataNode.value}`); // "0000..007F    ; Basic Latin  # [128] <control-0000>..<control-007F>"
+ *   console.log(`Raw content: ${dataNode.raw}`); // Same as value for data nodes
+ *   console.log(`Line number: ${dataNode.line}`); // 1
  * }
  * ```
  */
@@ -96,18 +139,23 @@ export function isDataNode(node: unknown): node is DataNode {
 }
 
 /**
- * Type guard function that checks if an unknown value is a DataFileEmptyNode.
- * A DataFileEmptyNode must be a valid DataFileNode with the type property set to "empty".
+ * Type guard function that checks if an unknown value is an EmptyNode.
+ * An EmptyNode must be a valid Node with the type property set to "empty".
  *
  * @param {unknown} node - The unknown value to check
- * @returns {node is EmptyNode} True if the node is a valid DataFileEmptyNode, false otherwise
+ * @returns {node is EmptyNode} True if the node is a valid EmptyNode, false otherwise
  *
  * @example
  * ```typescript
- * const unknownValue = getSomeData();
- * if (isEmptyNode(unknownValue)) {
- *   // TypeScript now knows this is a DataFileEmptyNode
- *   console.log(`Found empty node: ${unknownValue.raw}`);
+ * import { parseDataFile } from './parser';
+ *
+ * const parsedData = parseDataFile('# Comment\n\n0000; NULL');
+ * const emptyNode = parsedData.children[1]; // The blank line
+ *
+ * if (isEmptyNode(emptyNode)) {
+ *   console.log(`Empty node raw: "${emptyNode.raw}"`); // ""
+ *   console.log(`Empty node value: "${emptyNode.value}"`); // ""
+ *   console.log(`Line number: ${emptyNode.line}`); // 2
  * }
  * ```
  */
@@ -116,18 +164,22 @@ export function isEmptyNode(node: unknown): node is EmptyNode {
 }
 
 /**
- * Type guard function that checks if an unknown value is a DataFileRootNode.
- * A DataFileRootNode must be a valid DataFileNode with the type property set to "root".
+ * Type guard function that checks if an unknown value is a RootNode.
+ * A RootNode must be a valid Node with the type property set to "root".
  *
  * @param {unknown} node - The unknown value to check
- * @returns {node is RootNode} True if the node is a valid DataFileRootNode, false otherwise
+ * @returns {node is RootNode} True if the node is a valid RootNode, false otherwise
  *
  * @example
  * ```typescript
- * const unknownValue = getSomeData();
- * if (isRootNode(unknownValue)) {
- *   // TypeScript now knows this is a DataFileRootNode
- *   console.log(`Root node has ${unknownValue.children.length} children`);
+ * import { parseDataFile } from './parser';
+ *
+ * const parsedData = parseDataFile('# Unicode Block Data\n0000..007F; Basic Latin');
+ *
+ * if (isRootNode(parsedData)) {
+ *   console.log(`Root has ${parsedData.children.length} children`); // 2
+ *   console.log(`File name: ${parsedData.fileName}`); // May be undefined
+ *   console.log(`Version: ${parsedData.version}`); // May be undefined
  * }
  * ```
  */
@@ -136,18 +188,24 @@ export function isRootNode(node: unknown): node is RootNode {
 }
 
 /**
- * Type guard function that checks if an unknown value is a DataFileUnknownNode.
- * A DataFileUnknownNode must be a valid DataFileNode with the type property set to "unknown".
+ * Type guard function that checks if an unknown value is an UnknownNode.
+ * An UnknownNode must be a valid Node with the type property set to "unknown".
  *
  * @param {unknown} node - The unknown value to check
- * @returns {node is UnknownNode} True if the node is a valid DataFileUnknownNode, false otherwise
+ * @returns {node is UnknownNode} True if the node is a valid UnknownNode, false otherwise
  *
  * @example
  * ```typescript
- * const unknownValue = getSomeData();
- * if (isUnknownNode(unknownValue)) {
- *   // TypeScript now knows this is a DataFileUnknownNode
- *   console.log(`Found unknown node: ${unknownValue.raw}`);
+ * import { parseDataFile } from './parser';
+ *
+ * // Assuming some unusual content that doesn't match known patterns
+ * const parsedData = parseDataFile('@@UNUSUAL_SYNTAX@@\n0000; NULL');
+ * const unknownNode = parsedData.children[0];
+ *
+ * if (isUnknownNode(unknownNode)) {
+ *   console.log(`Unknown node raw: ${unknownNode.raw}`); // "@@UNUSUAL_SYNTAX@@"
+ *   console.log(`Unknown node value: ${unknownNode.value}`); // "@@UNUSUAL_SYNTAX@@"
+ *   console.log(`Line number: ${unknownNode.line}`); // 1
  * }
  * ```
  */

--- a/test/datafiles/typeguards.test.ts
+++ b/test/datafiles/typeguards.test.ts
@@ -3,6 +3,7 @@ import {
   isBoundaryNode,
   isCommentNode,
   isDataNode,
+  isEmptyCommentNode,
   isEmptyNode,
   isNode,
   isRootNode,
@@ -16,6 +17,23 @@ describe("ast type guards", () => {
       { type: "comment", value: "Another comment", raw: "# Another comment", line: 2 },
     ])("should identify comment nodes", (node) => {
       expect(isCommentNode(node)).toBe(true);
+      expect(isEmptyCommentNode(node)).toBe(false);
+      expect(isNode(node)).toBe(true);
+      expect(isBoundaryNode(node)).toBe(false);
+      expect(isDataNode(node)).toBe(false);
+      expect(isEmptyNode(node)).toBe(false);
+      expect(isUnknownNode(node)).toBe(false);
+      expect(isRootNode(node)).toBe(false);
+    });
+  });
+
+  describe("empty comment node", () => {
+    it.each([
+      { type: "empty-comment", value: "", raw: "#", line: 1 },
+      { type: "empty-comment", value: "", raw: "# ", line: 2 },
+    ])("should identify empty comment nodes", (node) => {
+      expect(isEmptyCommentNode(node)).toBe(true);
+      expect(isCommentNode(node)).toBe(false);
       expect(isNode(node)).toBe(true);
       expect(isBoundaryNode(node)).toBe(false);
       expect(isDataNode(node)).toBe(false);
@@ -34,6 +52,7 @@ describe("ast type guards", () => {
       expect(isBoundaryNode(node)).toBe(true);
       expect(isNode(node)).toBe(true);
       expect(isCommentNode(node)).toBe(false);
+      expect(isEmptyCommentNode(node)).toBe(false);
       expect(isDataNode(node)).toBe(false);
       expect(isEmptyNode(node)).toBe(false);
       expect(isUnknownNode(node)).toBe(false);
@@ -49,6 +68,7 @@ describe("ast type guards", () => {
       expect(isDataNode(node)).toBe(true);
       expect(isNode(node)).toBe(true);
       expect(isCommentNode(node)).toBe(false);
+      expect(isEmptyCommentNode(node)).toBe(false);
       expect(isBoundaryNode(node)).toBe(false);
       expect(isEmptyNode(node)).toBe(false);
       expect(isUnknownNode(node)).toBe(false);
@@ -64,6 +84,7 @@ describe("ast type guards", () => {
       expect(isEmptyNode(node)).toBe(true);
       expect(isNode(node)).toBe(true);
       expect(isCommentNode(node)).toBe(false);
+      expect(isEmptyCommentNode(node)).toBe(false);
       expect(isBoundaryNode(node)).toBe(false);
       expect(isDataNode(node)).toBe(false);
       expect(isUnknownNode(node)).toBe(false);
@@ -79,6 +100,7 @@ describe("ast type guards", () => {
       expect(isUnknownNode(node)).toBe(true);
       expect(isNode(node)).toBe(true);
       expect(isCommentNode(node)).toBe(false);
+      expect(isEmptyCommentNode(node)).toBe(false);
       expect(isBoundaryNode(node)).toBe(false);
       expect(isDataNode(node)).toBe(false);
       expect(isEmptyNode(node)).toBe(false);
@@ -105,6 +127,7 @@ describe("ast type guards", () => {
       expect(isRootNode(node)).toBe(true);
       expect(isNode(node)).toBe(true);
       expect(isCommentNode(node)).toBe(false);
+      expect(isEmptyCommentNode(node)).toBe(false);
       expect(isBoundaryNode(node)).toBe(false);
       expect(isDataNode(node)).toBe(false);
       expect(isEmptyNode(node)).toBe(false);
@@ -126,6 +149,7 @@ describe("ast type guards", () => {
     ])("should return false for $case", ({ value }) => {
       expect(isNode(value)).toBe(false);
       expect(isCommentNode(value)).toBe(false);
+      expect(isEmptyCommentNode(value)).toBe(false);
       expect(isBoundaryNode(value)).toBe(false);
       expect(isDataNode(value)).toBe(false);
       expect(isEmptyNode(value)).toBe(false);

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -50,6 +50,7 @@ it("exports-snapshot", async () => {
       hasSections: "function",
       isBoundaryNode: "function",
       isCommentNode: "function",
+      isEmptyCommentNode: "function",
       isDataNode: "function",
       isEmptyNode: "function",
       isNode: "function",


### PR DESCRIPTION
This PR adds a new node type named `EmptyCommentNode` which corresponds to a NodeComment but without any text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new node type called "empty-comment" for improved data handling.
  - Added a new function to identify "empty-comment" nodes.

- **Documentation**
  - Updated usage examples and descriptions for type guard functions to improve clarity and consistency.

- **Tests**
  - Enhanced test coverage to include the new "empty-comment" node type and its identification function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->