### PR TITLE
fix: handle empty comments

### DIFF
--- a/src/datafile/parser.ts
+++ b/src/datafile/parser.ts
@@ -12,6 +12,7 @@ import {
   isCommentLine,
   isEmptyLine,
   isLineWithData,
+  trimCommentLine,
 } from "../line-helpers";
 import { NodeTypes } from "./ast";
 
@@ -61,9 +62,10 @@ function createNode(line: string, lineNumber: number): ChildNode {
   }
 
   if (isCommentLine(line)) {
+    const trimmedComment = trimCommentLine(line);
     return {
-      type: NodeTypes.COMMENT,
-      value: trimmedLine.substring(1).trim(),
+      type: trimmedComment === "" ? NodeTypes.EMPTY_COMMENT : NodeTypes.COMMENT,
+      value: trimmedComment,
       raw: line,
       line: lineNumber,
     };

--- a/src/line-helpers.ts
+++ b/src/line-helpers.ts
@@ -176,6 +176,32 @@ export function isCommentLine(line: string): boolean {
 }
 
 /**
+ * Removes the comment marker ('#') and any following whitespace from a line.
+ *
+ * This function is designed to extract the actual content from comment lines
+ * in Unicode data files by removing the leading '#' character and any whitespace
+ * that follows it.
+ *
+ * @param {string} line - The comment line to trim
+ * @returns {string} The content of the comment line without the comment marker
+ *
+ * @example
+ * ```ts
+ * trimCommentLine("# Some comment"); // returns "Some comment"
+ * trimCommentLine("#\tTabbed comment"); // returns "Tabbed comment"
+ * trimCommentLine(""); // returns ""
+ * ```
+ */
+export function trimCommentLine(line: string): string {
+  if (!line) {
+    return "";
+  }
+
+  // remove leading '#' and any whitespace after it
+  return line.trim().replace(/^#\s*/, "");
+}
+
+/**
  * Checks if a string line is empty after trimming whitespace.
  *
  * @param {string} line - The string to check for emptiness

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -31,6 +31,7 @@ it("exports-snapshot", async () => {
       RawDataFile: "function",
       resolveUCDVersion: "function",
       stripHex: "function",
+      trimCommentLine: "function",
       UCD_PATH_MAPPINGS: "object",
       UNICODE_DRAFT_VERSION: "string",
       UNICODE_STABLE_VERSION: "string",
@@ -73,6 +74,7 @@ it("exports-snapshot", async () => {
       isMissingAnnotation: "function",
       parseFileNameLine: "function",
       parseMissingAnnotation: "function",
+      trimCommentLine: "function",
     },
   });
 });

--- a/test/line-helpers.test.ts
+++ b/test/line-helpers.test.ts
@@ -9,6 +9,7 @@ import {
   isLineWithData,
   isMissingAnnotation,
   parseMissingAnnotation,
+  trimCommentLine,
 } from "../src/line-helpers";
 
 describe("missing annotation", () => {
@@ -157,6 +158,26 @@ describe("isLineWithData", () => {
     ["special chars !@#", true],
   ])("should correctly identify '%s' as %s", (line, expected) => {
     expect(isLineWithData(line)).toBe(expected);
+  });
+});
+
+describe("trimCommentLine", () => {
+  it.each([
+    ["# This is a comment", "This is a comment"],
+    ["# Another comment line", "Another comment line"],
+    ["#   Leading and trailing spaces   ", "Leading and trailing spaces"],
+    ["#  ", ""],
+    ["#\tTabbed comment", "Tabbed comment"],
+    ["#\nNewline in comment", "Newline in comment"],
+    ["# Special characters !@#$%^&*()", "Special characters !@#$%^&*()"],
+    ["# 1234567890", "1234567890"],
+    ["# ", ""],
+    ["#\t", ""],
+    ["#\n", ""],
+    ["#", ""],
+    ["", ""],
+  ])("should trim comment line '%s' to '%s'", (line, expected) => {
+    expect(trimCommentLine(line)).toBe(expected);
   });
 });
 


### PR DESCRIPTION
This PR handles empty comments in the parse `createNode` that gets called for each line when parsing a DataFile.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new function to clean up comment lines by removing leading symbols and whitespace.
- **Bug Fixes**
  - Improved handling of empty comment lines for more accurate parsing.
- **Tests**
  - Added comprehensive tests for the new comment line trimming functionality.
  - Updated export tests to include the new function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->